### PR TITLE
Prevent handleAddFood from adding undefined value

### DIFF
--- a/src/components/SpicyFoodList.js
+++ b/src/components/SpicyFoodList.js
@@ -6,6 +6,7 @@ function SpicyFoodList() {
 
   function handleAddFood() {
     const newFood = getNewSpicyFood();
+    if (newFood === undefined) return;
     console.log(newFood);
   }
 


### PR DESCRIPTION
Prevent newFood from being added to the foods array when it's value is undefined from calling getNewSpicyFood
function, which returns undefined when the array is empty causing the app
to crash.